### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ fastlane/test_output
 # End of https://www.gitignore.io/api/git,macos,swift,xcode
 
 Pods
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "LibSignalProtocolSwift",
+    platforms: [
+        .iOS(.v12),
+        .macOS(.v10_15),
+        .tvOS(.v9),
+        .watchOS(.v4)
+    ],
+    products: [
+        .library(
+            name: "SignalProtocol",
+            targets: ["SignalProtocol"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.5.0"),
+        .package(url: "https://github.com/christophhagen/Curve25519.git", from: "2.0.0")
+    ],
+    targets: [
+        .target(
+            name: "CommonCryptoModule",
+            path: "Sources/CommonCryptoModule",
+            publicHeadersPath: "."
+        ),
+        .target(
+            name: "SignalProtocol",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "Curve25519", package: "Curve25519"),
+                "CommonCryptoModule"
+            ],
+            path: "Sources",
+            exclude: ["Info", "CommonCryptoModule"],
+            resources: [
+                .process("Info")
+            ]
+        ),
+        .testTarget(
+            name: "SignalProtocolTests",
+            dependencies: ["SignalProtocol"],
+            path: "Tests",
+            exclude: ["Info.plist"]
+        ),
+    ]
+)

--- a/Sources/CommonCryptoModule/CommonCryptoBridge/CommonCryptoBridge.h
+++ b/Sources/CommonCryptoModule/CommonCryptoBridge/CommonCryptoBridge.h
@@ -1,0 +1,6 @@
+#ifndef __COMMONCRYPTO_BRIDGE__
+#define __COMMONCRYPTO_BRIDGE__
+
+#include <CommonCrypto/CommonCrypto.h>
+
+#endif /* __COMMONCRYPTO_BRIDGE__ */

--- a/Sources/CommonCryptoModule/CommonCryptoBridge/module.modulemap
+++ b/Sources/CommonCryptoModule/CommonCryptoBridge/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCryptoBridge [system] {
+    header "CommonCryptoBridge.h"
+    export *
+}

--- a/Sources/CommonCryptoModule/CommonCryptoModule.h
+++ b/Sources/CommonCryptoModule/CommonCryptoModule.h
@@ -1,0 +1,17 @@
+//
+//  CommonCryptoModule.h
+//  CommonCryptoModule
+//
+//  Generated for Swift Package support
+//
+
+@import Foundation;
+
+//! Project version number for CommonCryptoModule.
+FOUNDATION_EXPORT double CommonCryptoModuleVersionNumber;
+
+//! Project version string for CommonCryptoModule.
+FOUNDATION_EXPORT const unsigned char CommonCryptoModuleVersionString[];
+
+// Trampoline CommonCrypto with CommonCryptoModule imports.
+@import CommonCryptoBridge;

--- a/Sources/CommonCryptoModule/Empty.swift
+++ b/Sources/CommonCryptoModule/Empty.swift
@@ -1,0 +1,1 @@
+// This file is an implementation detail, please ignore.


### PR DESCRIPTION
## Summary
- add `Package.swift` manifest for Swift Package Manager
- include a minimal `CommonCryptoModule` shim
- ignore `Package.resolved`

## Testing
- `swift package resolve`
- `swift build` *(fails: cannot find `SecRandomCopyBytes` in scope)*

------
https://chatgpt.com/codex/tasks/task_e_684d8ea5300883279685e5b4cc58fa62